### PR TITLE
Add reasoning pattern selection to agent nodes

### DIFF
--- a/.codes/config.json
+++ b/.codes/config.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "projectType": "node",
-  "setupDate": "Mon May 19 20:59:03 UTC 2025",
+  "setupDate": "Wed May 21 02:10:53 UTC 2025",
   "features": {
     "linting": true,
     "testing": true,

--- a/client/agent-nodes.js
+++ b/client/agent-nodes.js
@@ -341,6 +341,9 @@ const AgentNodes = {
       node.width = 240;
       node.height = 200;
 
+      // Default reasoning pattern
+      node.reasoningPattern = 'chain-of-thought';
+
       // Add agent-specific properties
       node.agentType = 'default';       // Type of agent (default, custom, etc.)
       node.tools = [];                  // Available tools for this agent
@@ -856,6 +859,11 @@ ${isFinal ? '\nThis is your final reflection. Summarize your overall approach, r
           { role: 'system', content: systemPrompt },
           { role: 'user', content: input }
         ];
+
+        // Apply reasoning pattern modifications
+        if (typeof ReasoningPatterns !== 'undefined') {
+          ReasoningPatterns.applyPattern(node, messages);
+        }
 
         // Add any context from memory
         const memory = AgentMemory.getContext(node);
@@ -1761,6 +1769,11 @@ ${isFinal ? '\nThis is your final reflection. Summarize your overall approach, r
       systemPromptInput.value = node.systemPrompt || '';
     }
 
+    const reasoningPatternSelect = document.getElementById('reasoningPattern');
+    if (reasoningPatternSelect) {
+      reasoningPatternSelect.value = node.reasoningPattern || 'chain-of-thought';
+    }
+
     const maxIterationsInput = document.getElementById('maxIterations');
     if (maxIterationsInput) {
       maxIterationsInput.value = node.maxIterations || 5;
@@ -1962,6 +1975,12 @@ ${isFinal ? '\nThis is your final reflection. Summarize your overall approach, r
       const systemPromptInput = document.getElementById('agentSystemPrompt');
       if (systemPromptInput) {
         node.systemPrompt = systemPromptInput.value;
+      }
+
+      const reasoningPatternSelect = document.getElementById('reasoningPattern');
+      if (reasoningPatternSelect) {
+        node.reasoningPattern = reasoningPatternSelect.value || 'chain-of-thought';
+        DebugManager.addLog(`Set reasoning pattern to: ${node.reasoningPattern}`, 'info');
       }
 
       const maxIterationsInput = document.getElementById('maxIterations');

--- a/client/app.js
+++ b/client/app.js
@@ -275,6 +275,9 @@ class Node {
 
     // For chat nodes
     this.chatHistory = []; // Array of chat messages with {role: 'user'|'assistant', content: string}
+
+    // Reasoning pattern to use when processing with AI
+    this.reasoningPattern = 'chain-of-thought';
   }
 
   getContentTypeIcon() {

--- a/client/index.html
+++ b/client/index.html
@@ -685,6 +685,18 @@
         </div>
 
         <div class="form-group">
+          <label for="reasoningPattern">Reasoning Pattern:</label>
+          <select id="reasoningPattern" class="form-control">
+            <option value="chain-of-thought">Chain of Thought</option>
+            <option value="tree-of-thought">Tree of Thought</option>
+            <option value="react">ReAct</option>
+            <option value="reflection">Reflection</option>
+            <option value="planning">Planning</option>
+            <option value="reflective">Reflective</option>
+          </select>
+        </div>
+
+        <div class="form-group">
           <label for="maxIterations">Maximum Iterations:</label>
           <input type="number" id="maxIterations" class="form-control" min="1" max="20" value="5">
         </div>
@@ -867,6 +879,7 @@
   <script src="agent-tools.js"></script>
   <script src="agent-planner.js"></script>
   <script src="agent-logger.js"></script>
+  <script src="reasoning-patterns.js"></script>
   <script src="mcp-tools.js"></script>
   <script src="agent-nodes.js"></script>
   <script src="keyboard-config.js" type="module"></script>

--- a/client/main.js
+++ b/client/main.js
@@ -151,6 +151,9 @@ class Node {
     this.inputs = [];
     this.selected = false;
     this.processed = false;
+
+    // Reasoning pattern for AI processing
+    this.reasoningPattern = 'chain-of-thought';
   }
 
   async processContent(inputContent, inputModality) {

--- a/client/reasoning-patterns.js
+++ b/client/reasoning-patterns.js
@@ -1,0 +1,18 @@
+const ReasoningPatterns = {
+  applyPattern(node, messages) {
+    if (!node || !Array.isArray(messages) || messages.length === 0) return messages;
+    const instructionMap = {
+      'chain-of-thought': 'Please reason step by step before you answer.',
+      'tree-of-thought': 'Explore multiple possible reasoning branches before deciding on an answer.',
+      'react': 'Use the ReAct approach: alternate reasoning with tool use when needed.',
+      'reflection': 'Reflect on prior steps and consider improvements before answering.',
+      'planning': 'Begin by writing a short plan of action before executing any steps.',
+      'reflective': 'After reasoning, briefly reflect on your answer before responding.'
+    };
+    const extra = instructionMap[node.reasoningPattern];
+    if (extra && messages[0].role === 'system') {
+      messages[0].content = messages[0].content + ' ' + extra;
+    }
+    return messages;
+  }
+};


### PR DESCRIPTION
## Summary
- extend reasoning-patterns with ReAct, planning and reflective modes
- load reasoning pattern script in the client
- allow selecting reasoning pattern in Agent Node editor
- store reasoning pattern when saving agent nodes

## Testing
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable "Reasoning Pattern" option for agent nodes, allowing users to select from various reasoning strategies such as Chain of Thought, Tree of Thought, ReAct, Reflection, Planning, and Reflective.
	- Added a dropdown menu in the Agent Node Editor for selecting the reasoning pattern.
	- Agent processing now adapts prompts based on the chosen reasoning pattern.
- **Chores**
	- Updated configuration data with a new setup date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->